### PR TITLE
Add other sublattice to output. Added plaquette view to output.

### DIFF
--- a/src/datamodel/lattice.rs
+++ b/src/datamodel/lattice.rs
@@ -4,14 +4,14 @@ use super::Point;
 use super::Vertex;
 
 /// Stores the representation of the sytem
-/// 
-/// 
+///
+///
 /// All links can be defined by the vertices of one sublattice.
 /// This means the len of vertices will always be N/2, where N is the
 /// total number of vertices.
 /// TODO: Do a check or asertation to ensure the length of vertices
-/// is correct given Point. 
-/// 
+/// is correct given Point.
+///
 /// ```
 ///     |   |   |   |
 ///     +---6---+---7---
@@ -183,15 +183,16 @@ pub fn build_blank_lat(size: Point) -> Lattice {
     lat
 }
 
-
-//     |   |   |   |
-//     +->-6->-+->-7->-
-//     |   |   |   |
-//     4->-+->-5->-+->-
-//     |   |   |   |
-//     +->-2->-+->-3->-
-//     |   |   |   |
-//     0->-+->-1->-+->-
+/// ```
+///     |   |   |   |
+///     +->-6->-+->-7->-
+///     |   |   |   |
+///     4->-+->-5->-+->-
+///     |   |   |   |
+///     +->-2->-+->-3->-
+///     |   |   |   |
+///     0->-+->-1->-+->-
+///  ```
 pub fn build_z3_striped_lat(size: Point) -> Lattice {
     println!("Building stagard lattice of size x {}, y {}",
              size.x, size.y);

--- a/src/datamodel/mod.rs
+++ b/src/datamodel/mod.rs
@@ -21,6 +21,13 @@ impl Link {
             Link::Blank => {Link::Blank}
         }
     }
+    pub fn soft_flip(link: &Link) -> Link {
+        match link{
+            Link::In => {Link::Out}
+            Link::Out => {Link::In}
+            Link::Blank => {Link::Blank}
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/datamodel/mod.rs
+++ b/src/datamodel/mod.rs
@@ -7,6 +7,31 @@ use std::ops::Add;
 use std::slice::Iter;
 
 
+/// An AbsolutePlaquett is a plaquett view of the surounding links where the links are specified
+/// using the absolute reference of the axes. The vertex objexts have links with directions
+/// that are specified relative to the vertex, ie "In", "Out". An "Absolute" object will specify
+/// link values with respect to the axis.
+///
+/// A plaquett view:
+/// ```
+/// -----
+/// | + |
+/// -----
+/// ```
+/// `|` and `--` denote the horizontal and vertical links respectively.
+/// The `+` marks the center of the plaquett
+//#[derive(Debug, Clone, Copy)]
+//pub enum AbsolutePlaquett {
+//
+//}
+
+//#[derive(Debug, Clone, Copy)]
+//pub enum AbsoluteLink {
+//    PlussOne,
+//    MinusOne,
+//    Blank
+//}
+
 #[derive(Debug, Clone, Copy)]
 pub enum Link {
     In,

--- a/src/estimators/correlation_origin_estimator.rs
+++ b/src/estimators/correlation_origin_estimator.rs
@@ -9,7 +9,6 @@ use std::io::BufWriter;
 use std::fs::File;
 use std::path::Path;
 use std::io::prelude::*;
-use std::error::Error;
 
 fn simple_file_make_helper_function(direction_string: &str,
                                     orientation_string: &str) -> BufWriter<File> {
@@ -22,7 +21,7 @@ fn simple_file_make_helper_function(direction_string: &str,
     let path = Path::new(&file_name_string);
     let display = path.display();
     let file = match File::create(&path){
-        Err(err) => panic!("could not create {}: {}", display, err.description()),
+        Err(err) => panic!("could not create {}: {}", display, err),
         Ok(good_file) => good_file,
     };
     return BufWriter::new(file);
@@ -163,25 +162,25 @@ impl Measurable for CorrelationOriginEstimator {
 
         match self.result_file_buffer_horizontal_out
                 .write(ho_out_string.as_bytes()){
-            Err(err) => panic!("Can't write to origin estimator buff: {}", err.description()),
+            Err(err) => panic!("Can't write to origin estimator buff: {}", err),
             //Ok(_) => println!("Wrote measurment to origin estimator buffer.") ,
             Ok(_) => (),
         }
         match self.result_file_buffer_horizontal_in
                 .write(hi_out_string.as_bytes()){
-            Err(err) => panic!("Can't write to origin estimator buff: {}", err.description()),
+            Err(err) => panic!("Can't write to origin estimator buff: {}", err),
             //Ok(_) => println!("Wrote measurment to origin estimator buffer.") ,
             Ok(_) => (),
         }
         match self.result_file_buffer_vertical_out
                 .write(vo_out_string.as_bytes()){
-            Err(err) => panic!("Can't write to origin estimator buff: {}", err.description()),
+            Err(err) => panic!("Can't write to origin estimator buff: {}", err),
             //Ok(_) => println!("Wrote measurment to origin estimator buffer.") ,
             Ok(_) => (),
         }
         match self.result_file_buffer_vertical_in
                 .write(vi_out_string.as_bytes()){
-            Err(err) => panic!("Can't write to origin estimator buff: {}", err.description()),
+            Err(err) => panic!("Can't write to origin estimator buff: {}", err),
             //Ok(_) => println!("Wrote measurment to origin estimator buffer.") ,
             Ok(_) => (),
         }

--- a/src/estimators/density_estimator.rs
+++ b/src/estimators/density_estimator.rs
@@ -7,7 +7,6 @@ use super::super::datamodel::lattice::Lattice;
 use std::io::prelude::*;
 use std::fs::File;
 use std::path::Path;
-use std::error::Error;
 use std::io::BufWriter;
 
 /// Measures the string density
@@ -34,7 +33,7 @@ impl DensityEstimator {
         let file = match File::create(&path){
             Err(err) => panic!("could not create {}: {}",
                             display,
-                            err.description()),
+                            err),
             Ok(good_file) => good_file,
         };
 
@@ -73,7 +72,7 @@ impl DensityEstimator {
         let mut file = match File::create(&path){
             Err(err) => panic!("could not create {}: {}",
                             display,
-                            err.description()),
+                            err),
             Ok(good_file) => good_file,
         };
         
@@ -98,7 +97,7 @@ impl DensityEstimator {
         match file.write_all(out_string.as_bytes()){
             Err(err) => panic!("could not create {}: {}",
                             display,
-                            err.description()),
+                            err),
             Ok(_) => println!("file out worked"),
         }
     }
@@ -127,7 +126,7 @@ impl Measurable for DensityEstimator {
         out_string.push_str("\n");
         match self.result_file_buffer.write(out_string.as_bytes()){
             Err(err) => panic!("Can not write to density estimator buffer: {}",
-                err.description()),
+                err),
             //Ok(_) => println!("Wrote measurement to density estimator buffer.") ,
             Ok(_) => (),
         }

--- a/src/estimators/total_link_count_estimator.rs
+++ b/src/estimators/total_link_count_estimator.rs
@@ -24,7 +24,7 @@ impl TotalLinkCountEstimator {
         let file = match File::create(&path) {
             Err(err) => panic!("could not create {}: {}",
                 display,
-                err.description()),
+                err),
             Ok(good_file) => good_file,
         };
 
@@ -60,7 +60,7 @@ impl Measurable for TotalLinkCountEstimator {
 
         match self.result_file_buffer.write(out_string.as_bytes()){
             Err(err) => panic!("Can not write to total link count estimator buffer {}",
-                err.description()),
+                err),
             Ok(_) => (),
         }
     }

--- a/src/estimators/winding_number_estimator.rs
+++ b/src/estimators/winding_number_estimator.rs
@@ -1,6 +1,5 @@
 use std::fs::File;
 use std::path::Path;
-use std::error::Error;
 use std::io::BufWriter;
 use super::Measurable;
 use std::io::prelude::*;
@@ -26,7 +25,7 @@ impl WindingNumberCountEstimator {
         let file = match File::create(&path) {
             Err(err) => panic!("could not create {}: {}",
                 display,
-                err.description()),
+                err),
             Ok(good_file) => good_file,
         };
 
@@ -214,7 +213,7 @@ impl Measurable for WindingNumberCountEstimator {
 
         match self.result_file_buffer.write(out_string.as_bytes()) {
             Err(err) => panic!("Can not write to winding count estimator file {}",
-                err.description()
+                err
             ),
             Ok(_) => (),
         }

--- a/src/estimators/winding_variance_estimator.rs
+++ b/src/estimators/winding_variance_estimator.rs
@@ -1,6 +1,5 @@
 use std::fs::File;
 use std::path::Path;
-use std::error::Error;
 use std::io::BufWriter;
 use super::Measurable;
 use std::io::prelude::*;
@@ -29,7 +28,7 @@ impl WindingNumberVarianceEstimator {
         let file = match File::create(&path) {
             Err(err) => panic!("could not create {}: {}",
                 display,
-                err.description()),
+                err),
             Ok(good_file) => good_file,
         };
 
@@ -193,7 +192,7 @@ impl Measurable for WindingNumberVarianceEstimator {
 
         match self.result_file_buffer.write(out_string.as_bytes()) {
             Err(err) => panic!("Can not write to winding variance estimator file {}",
-                err.description()
+                err
             ),
             Ok(_) => (),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
     // Parse arguments
     let yaml = load_yaml!("cli.yml");
     let matches = App::from_yaml(yaml).get_matches();
-    
+
     let lattice_size_arg_str = matches.value_of("size").unwrap_or("4");
     let lattice_size_arg: i64 = lattice_size_arg_str.parse().unwrap();
     println!("Lattice size from argument: {}", lattice_size_arg);

--- a/src/oio/mod.rs
+++ b/src/oio/mod.rs
@@ -148,9 +148,17 @@ pub fn write_lattice(f_str: String, lat: &Lattice) -> std::io::Result<()> {
         );
         // Upper corner of plaquett 2
         let temp_loc4 = increment_loc(&Direction::N, &temp_loc2);
+        let temp_loc5 = increment_loc(&Direction::N, &temp_loc4);
+        let temp_loc6 = increment_loc(&Direction::E, &temp_loc4);
+        let temp_loc7 = increment_loc(&Direction::S, &temp_loc4);
+        let temp_loc8 = increment_loc(&Direction::W, &temp_loc4);
         println!("x: {} y: {}", temp_loc4.location.x, temp_loc4.location.y);
         let vertex_corner_2 = Vertex {
-            
+            n: Link::soft_flip(lat.safe_get_link_from_point(&temp_loc5.location, &Direction::S)),
+            e: Link::soft_flip(lat.safe_get_link_from_point(&temp_loc6.location, &Direction::W)),
+            s: Link::soft_flip(lat.safe_get_link_from_point(&temp_loc7.location, &Direction::N)),
+            w: Link::soft_flip(lat.safe_get_link_from_point(&temp_loc8.location, &Direction::E)),
+            xy: working_loc.location
         };
         plaquett_out_str.push_str(
             &format!(

--- a/src/oio/mod.rs
+++ b/src/oio/mod.rs
@@ -2,14 +2,41 @@ use std::io::prelude::*;
 use std::fs::File;
 use std::path::Path;
 use super::datamodel::Link;
+use super::datamodel::Direction;
+use super::datamodel::Vertex;
+use super::datamodel::Point;
+use super::datamodel::BoundPoint;
 use super::datamodel::lattice::Lattice;
 use std::error::Error;
+
 
 fn get_out_string_from_link(link: &Link) -> &str{
     match link{
         &Link::In => "In",
         &Link::Out => "Out",
         &Link::Blank => "Blank",
+    }
+}
+
+pub fn increment_loc(direction: &Direction, location_in: &BoundPoint) -> BoundPoint{
+    let increment: Option<Point>; 
+    match *direction {
+        Direction::N => {
+            increment = Some(Point {x: 0, y: 1});
+        },
+        Direction::E => {
+            increment = Some(Point {x: 1, y: 0});
+        },
+        Direction::S => {
+            increment = Some(Point {x: 0, y: -1});
+        },
+        Direction::W => {
+            increment = Some(Point {x: -1, y: 0});
+        },
+    }
+    return match increment {
+        Some(inc) => location_in + inc,
+        None => panic!("No step taken for some reason. No increment."),
     }
 }
 
@@ -23,22 +50,54 @@ pub fn write_lattice(f_str: String, lat: &Lattice) {
                            err.description()),
         Ok(good_file) => good_file,
     };
-    
+
     let mut out_string = String::new();
     out_string.push_str("x,y,N,E,S,W\n");
 
+    let mut working_loc: BoundPoint;
     for vertex in &lat.vertices{
-        //TODO: Need to write xy here.
         out_string.push_str(
-                &format!("{},{},{},{},{},{}\n",
-                        vertex.xy.x,
-                        vertex.xy.y,
-                        get_out_string_from_link(&vertex.n),
-                        get_out_string_from_link(&vertex.e),
-                        get_out_string_from_link(&vertex.s),
-                        get_out_string_from_link(&vertex.w),
-                        )
-                );
+            &format!("{},{},{},{},{},{}\n",
+                vertex.xy.x,
+                vertex.xy.y,
+                get_out_string_from_link(&vertex.n),
+                get_out_string_from_link(&vertex.e),
+                get_out_string_from_link(&vertex.s),
+                get_out_string_from_link(&vertex.w),
+                )
+        );
+        // Write the other sublattice as well
+
+        working_loc = BoundPoint {
+            size: lat.size,
+            location: vertex.xy,
+        };
+        working_loc = &working_loc + Point{x: 1, y: 0};
+
+        let temp_loc1 = increment_loc(&Direction::N, &working_loc);
+        let fake_vertex = Vertex{
+            n: Link::soft_flip(lat.safe_get_link_from_point(&temp_loc1.location, &Direction::S)),
+            e: Link::soft_flip(lat.safe_get_link_from_point(&temp_loc1.location, &Direction::S)),
+            s: Link::soft_flip(lat.safe_get_link_from_point(&temp_loc1.location, &Direction::S)),
+            w: Link::soft_flip(lat.safe_get_link_from_point(&temp_loc1.location, &Direction::S)),
+            xy: working_loc.location
+        };
+        out_string.push_str(
+            &format!("{},{},{},{},{},{}\n",
+                fake_vertex.xy.x,
+                fake_vertex.xy.y,
+                get_out_string_from_link(&fake_vertex.n),
+                get_out_string_from_link(&fake_vertex.e),
+                get_out_string_from_link(&fake_vertex.s),
+                get_out_string_from_link(&fake_vertex.w),
+                )
+        );
+        //temp_loc = increment_loc(&Direction::E, &working_loc);
+        //fake_vertex.n = lat.get_link_from_point(&temp_loc.location, &Direction::W).flip();
+        //temp_loc = increment_loc(&Direction::S, &working_loc);
+        //fake_vertex.n = lat.get_link_from_point(&temp_loc.location, &Direction::N).flip();
+        //temp_loc = increment_loc(&Direction::W, &working_loc);
+        //fake_vertex.n = lat.get_link_from_point(&temp_loc.location, &Direction::E).flip();
     }
     out_string.push_str("\n");
     println!("{}", out_string);
@@ -61,7 +120,7 @@ pub fn write_vec(f_str: String, vec: &Vec<u8>) {
                            err.description()),
         Ok(good_file) => good_file,
     };
-    
+
     let mut out_string = String::new();
     for i in vec{
         out_string.push_str(&format!("{} ", i));
@@ -81,7 +140,6 @@ pub fn write_vec(f_str: String, vec: &Vec<u8>) {
 
 
 pub fn write_2d_vec(vec: &Vec<Vec<i32>>) {
-
 
     let path = Path::new("foo.txt");
     let display = path.display();


### PR DESCRIPTION
Both sublattices are now written when the configuration output flag is set.

A plaquette view is also written. The plaquett view is specified using absolute orientations. An example of a plaquett view header and first line is:
```
x,y,N,E,S,W
0,0,E,N,B,B
```

The columns are

* `x`: horizontal position of plaquette
* `y`: vertical position of plaquette
* `N`: The top link of the plaquette
* `E`: The right link 
* `S`: The botom link
* `W`: The left link

The values in the example are 
* `x`: located at the `x=0` position
* `y` located at the `y=0` position
* The top link is pointing to the right
* The right link is pointing up
* The bottom link is blank
* The left link is blank