### PR TITLE
Create single file with all output configurations for gebre

### DIFF
--- a/src/cli.yml
+++ b/src/cli.yml
@@ -76,6 +76,7 @@ args:
           sublatice. (2) will write all configurations to a single file. Each row will be a list of all
           link values for the whole configuration. The first column will be the (x=0,y=0) vertex E(ast) link. The
           second column will be the (0,0) vertex N(orth) link. The third column will be the (1,0) vertex E link... etc.
+          ((0) will write every option for comparison)
     - loop-update:
         long: loop-update
         help: Boolean to trigger the use of loop updates instead of local

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -66,6 +66,16 @@ args:
         help: Boolean to trigger writing configuration after every bin
         takes_value: true
         required: false
+    - write-configuration-style:
+        long: write-configuration-style
+        value_name: write-configuration-style
+        multiple: false
+        help: Select the way you would like configurations to be written (provide integer 1 or 2). Currently there are 2 options.
+          (1) which will write a single file per configuration. That file will have columns
+          for the x, y corodenates of each vertex (from a single sublatice) and the "value" of the links around that
+          sublatice. (2) will write all configurations to a single file. Each row will be a list of all
+          link values for the whole configuration. The first column will be the (x=0,y=0) vertex E(ast) link. The
+          second column will be the (0,0) vertex N(orth) link. The third column will be the (1,0) vertex E link... etc.
     - loop-update:
         long: loop-update
         help: Boolean to trigger the use of loop updates instead of local

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,10 @@ fn main() {
     let write_bin_configurations: bool = write_bin_configurations_str.parse().unwrap();
     println!("Write bin configs: {}", write_bin_configurations);
 
+    let write_configuration_style_str: &str = matches.value_of("write-configuration-style").unwrap_or("flat");
+    let write_configuration_style: u8 = write_configuration_style_str.parse().unwrap();
+    println!("Write configuration style: {}", write_configuration_style);
+
     let update_type: &UpdateType = &UpdateType::Local;
     if matches.is_present("loop-update") {
         let update_type: &UpdateType = &UpdateType::Walk;
@@ -235,17 +239,17 @@ fn main() {
         for _i in 0..number_bins {
             println!("Working on bin {}", _i);
             if write_bin_configurations {
-                write_lattice(String::from(format!("lattice_bin_{}.csv", total_update_count)), &lat);
+                write_lattice(String::from(format!("lattice_bin_{}.csv", total_update_count)), &mut lat, write_configuration_style);
             }
             for _j in 0..number_measure {
                 //println!("j {}", _j);
                 if write_measure_configurations {
-                    write_lattice(String::from(format!("lattice_measure_{}.csv", total_update_count)), &lat);
+                    write_lattice(String::from(format!("lattice_measure_{}.csv", total_update_count)), &mut lat, write_configuration_style);
                 }
                 for _k in 0..number_update {
                     //println!("k {}", _k);
                     if write_update_configurations {
-                        write_lattice(String::from(format!("lattice_{}.csv", total_update_count)), &lat);
+                        write_lattice(String::from(format!("lattice_{}.csv", total_update_count)), &mut lat, write_configuration_style);
                     }
                     updater.main_update(&mut lat, &update_type);
                     total_update_count += 1;

--- a/src/oio/mod.rs
+++ b/src/oio/mod.rs
@@ -7,6 +7,7 @@ use super::datamodel::Vertex;
 use super::datamodel::Point;
 use super::datamodel::BoundPoint;
 use super::datamodel::lattice::Lattice;
+use std::slice::range;
 
 /// real_bool: If true this is link from a real vertex (lower left of plaquett)
 /// If false this is link from a fake vertex (upper right of plaquett)
@@ -73,7 +74,55 @@ pub fn increment_loc(direction: &Direction, location_in: &BoundPoint) -> BoundPo
     }
 }
 
-pub fn write_lattice(f_str: String, lat: &Lattice) -> std::io::Result<()> {
+pub fn write_lattice(f_str: String, lat: &mut Lattice, style: u8) -> std::io::Result<()> {
+    if style == 1 {
+        write_lattice_style_1(f_str, lat)
+    }
+    else if style == 2 {
+        write_lattice_style_2(lat)
+    }
+}
+
+pub fn write_lattice_style_2(lat: &mut Lattice) -> std::io::Result<()> {
+    let file_and_path = Path::new("lattice_configurations.csv");
+    let mut line_out_str= String::new();
+    let mut file_obj = File::create(&vertex_path)?;
+
+    for y in 0..lat.size.y {
+        for x in 0..lat.size.x {
+            let is_this_point_real = lat.point_real(&Point{x, y});
+
+            let current_vertex: Vertex = lat.get_vertex_from_point(
+                &BoundPoint{
+                    size: Point{
+                        x: lat.size.x, y: lat.size.y
+                    },
+                    location: Point{x, y}
+                }
+            );
+            // Next step is to change the strings into numbers using the "is_this_point_real"
+            // variable to determine how "In" "Out" map to numbers
+            line_out_str.push_str(
+                &format!("{},{}",
+                    match current_vertex.e{
+                        Link::In => "In",
+                        Link::Out => "Out",
+                        Link::Blank => "Blank",
+                    },
+                    match current_vertex.e{
+                        Link::In => "In",
+                        Link::Out => "Out",
+                        Link::Blank => "Blank",
+                    }
+                )
+            )
+        }
+    }
+    Ok(())
+}
+
+/// Style 1 <- read the cli.yml file for verbose description
+pub fn write_lattice_style_1(f_str: String, lat: &Lattice) -> std::io::Result<()> {
     let vertex_f_str: String = format!("{}_{}", "vertex", f_str);
     let plaquett_f_str: String = format!("{}_{}", "plaquett", f_str);
     let vertex_path = Path::new(&vertex_f_str);

--- a/src/oio/mod.rs
+++ b/src/oio/mod.rs
@@ -7,7 +7,6 @@ use super::datamodel::Vertex;
 use super::datamodel::Point;
 use super::datamodel::BoundPoint;
 use super::datamodel::lattice::Lattice;
-use std::slice::range;
 
 /// real_bool: If true this is link from a real vertex (lower left of plaquett)
 /// If false this is link from a fake vertex (upper right of plaquett)
@@ -74,19 +73,26 @@ pub fn increment_loc(direction: &Direction, location_in: &BoundPoint) -> BoundPo
     }
 }
 
-pub fn write_lattice(f_str: String, lat: &mut Lattice, style: u8) -> std::io::Result<()> {
+pub fn write_lattice(f_str: String, lat: &mut Lattice, style: u8) {
     if style == 1 {
-        write_lattice_style_1(f_str, lat)
+        write_lattice_style_1(f_str, lat);
     }
     else if style == 2 {
-        write_lattice_style_2(lat)
+        write_lattice_style_2(lat);
+    }
+    else if style == 0 {
+        write_lattice_style_1(f_str, lat);
+        write_lattice_style_2(lat);
     }
 }
 
-pub fn write_lattice_style_2(lat: &mut Lattice) -> std::io::Result<()> {
+pub fn write_lattice_style_2(lat: &mut Lattice) {
     let file_and_path = Path::new("lattice_configurations.csv");
     let mut line_out_str= String::new();
-    let mut file_obj = File::create(&vertex_path)?;
+    let mut file_obj = match File::create(&file_and_path) {
+        Ok(f) => f,
+        Err(e) => panic!("Problem creating file to write configurations: {}", e)
+    };
 
     for y in 0..lat.size.y {
         for x in 0..lat.size.x {
@@ -100,36 +106,73 @@ pub fn write_lattice_style_2(lat: &mut Lattice) -> std::io::Result<()> {
                     location: Point{x, y}
                 }
             );
-            // Next step is to change the strings into numbers using the "is_this_point_real"
-            // variable to determine how "In" "Out" map to numbers
-            line_out_str.push_str(
-                &format!("{},{}",
-                    match current_vertex.e{
-                        Link::In => "In",
-                        Link::Out => "Out",
-                        Link::Blank => "Blank",
-                    },
-                    match current_vertex.e{
-                        Link::In => "In",
-                        Link::Out => "Out",
-                        Link::Blank => "Blank",
-                    }
+
+            let mut final_comma_str = ",";
+            if x == lat.size.x {
+                final_comma_str = "";
+            }
+
+            if is_this_point_real {
+                line_out_str.push_str(
+                    &format!(
+                        "{},{}{}",
+                         match current_vertex.e{
+                             Link::In => 1,
+                             Link::Out => 2,
+                             Link::Blank => 0,
+                         },
+                         match current_vertex.n{
+                             Link::In => 1,
+                             Link::Out => 2,
+                             Link::Blank => 0,
+                         },
+                        final_comma_str
+                    )
                 )
-            )
+            }
+            else {
+                line_out_str.push_str(
+                    &format!(
+                        "{},{}{}",
+                         match current_vertex.e{
+                             Link::In => 2,
+                             Link::Out => 1,
+                             Link::Blank => 0,
+                         },
+                         match current_vertex.n{
+                             Link::In => 2,
+                             Link::Out => 1,
+                             Link::Blank => 0,
+                         },
+                        final_comma_str
+                    )
+                )
+            }
         }
     }
-    Ok(())
+    line_out_str.push_str("\n");
+
+    match file_obj.write_all(line_out_str.as_bytes()) {
+        Ok(()) => println!("Wrote configuration to file (2)"),
+        Err(_) => panic!("Problem writing configuration (2)")
+    }
 }
 
 /// Style 1 <- read the cli.yml file for verbose description
-pub fn write_lattice_style_1(f_str: String, lat: &Lattice) -> std::io::Result<()> {
+pub fn write_lattice_style_1(f_str: String, lat: &Lattice) {
     let vertex_f_str: String = format!("{}_{}", "vertex", f_str);
     let plaquett_f_str: String = format!("{}_{}", "plaquett", f_str);
     let vertex_path = Path::new(&vertex_f_str);
     let plaquett_path = Path::new(&plaquett_f_str);
 
-    let mut vertex_file = File::create(&vertex_path)?;
-    let mut plaquett_file = File::create(&plaquett_path)?;
+    let mut vertex_file = match File::create(&vertex_path) {
+        Ok(f) => f,
+        Err(e) => panic!("Problem creating vertex config file: {}", e)
+    };
+    let mut plaquett_file = match File::create(&plaquett_path) {
+        Ok(f) => f,
+        Err(e) => panic!("Problem creating plaquett config file: {}", e)
+    };
 
     let mut vertex_out_str= String::new();
     vertex_out_str.push_str("x,y,N,E,S,W\n");
@@ -224,10 +267,15 @@ pub fn write_lattice_style_1(f_str: String, lat: &Lattice) -> std::io::Result<()
     vertex_out_str.push_str("\n");
     plaquett_out_str.push_str("\n");
 
-    vertex_file.write_all(vertex_out_str.as_bytes())?;
-    plaquett_file.write_all(plaquett_out_str.as_bytes())?;
+    match vertex_file.write_all(vertex_out_str.as_bytes()) {
+        Ok(()) => println!("Wrote vertex configuration to file (1)"),
+        Err(_) => panic!("Problem vertex writing configuration (1)")
+    }
+    match plaquett_file.write_all(plaquett_out_str.as_bytes()) {
+        Ok(()) => println!("Wrote plaquett configuration to file (1)"),
+        Err(_) => panic!("Problem plaquett writing configuration (1)")
+    }
 
-    Ok(())
 }
 
 pub fn write_vec(f_str: String, vec: &Vec<u8>) {

--- a/src/oio/mod.rs
+++ b/src/oio/mod.rs
@@ -96,7 +96,6 @@ pub fn write_lattice_style_2(lat: &mut Lattice) {
 
     for y in 0..lat.size.y {
         for x in 0..lat.size.x {
-            let is_this_point_real = lat.point_real(&Point{x, y});
 
             let current_vertex: Vertex = lat.get_vertex_from_point(
                 &BoundPoint{
@@ -112,42 +111,22 @@ pub fn write_lattice_style_2(lat: &mut Lattice) {
                 final_comma_str = "";
             }
 
-            if is_this_point_real {
-                line_out_str.push_str(
-                    &format!(
-                        "{},{}{}",
-                         match current_vertex.e{
-                             Link::In => 1,
-                             Link::Out => 2,
-                             Link::Blank => 0,
-                         },
-                         match current_vertex.n{
-                             Link::In => 1,
-                             Link::Out => 2,
-                             Link::Blank => 0,
-                         },
-                        final_comma_str
-                    )
+            line_out_str.push_str(
+                &format!(
+                    "{},{}{}",
+                     match current_vertex.e{
+                         Link::In => 2,
+                         Link::Out => 1,
+                         Link::Blank => 0,
+                     },
+                     match current_vertex.n{
+                         Link::In => 2,
+                         Link::Out => 1,
+                         Link::Blank => 0,
+                     },
+                    final_comma_str
                 )
-            }
-            else {
-                line_out_str.push_str(
-                    &format!(
-                        "{},{}{}",
-                         match current_vertex.e{
-                             Link::In => 2,
-                             Link::Out => 1,
-                             Link::Blank => 0,
-                         },
-                         match current_vertex.n{
-                             Link::In => 2,
-                             Link::Out => 1,
-                             Link::Blank => 0,
-                         },
-                        final_comma_str
-                    )
-                )
-            }
+            )
         }
     }
     line_out_str.push_str("\n");


### PR DESCRIPTION
We want to output configurations in a single file where each row represents one configuration.

I have added a new flat `--write-configuration-style` which lets you select the way you would like configurations to be written (provide integer 1 or 2). Currently, there are 2 options.

(1) which will write a single file per configuration. That file will have columns for the x, y coordinates of each vertex (from a single sublattice) and the "value" of the links around that sublattice. 

(2) will write all configurations to a single file. Each row will be a list of all link values for the whole configuration. The first column will be the (x=0,y=0) vertex E(ast) link. The second column will be the (0,0) vertex N(orth) link. The third column will be the (1,0) vertex E link... etc.

((0) will write every option for comparison)
